### PR TITLE
Add BSD 2-Clause License Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,32 @@ We welcome community contributions! Here are some ideas for future enhancements:
 Contributions are welcome. If you have an idea for optimisation of existing features or improvement, please open a PR on GitHub.
 Please refer to [CONTRIBUTING.md](https://github.com/etsi-ai/etsi-failprint/blob/main/CONTRIBUTING.md) for contribution guidelines and ensure
 
+## License
+
+This repository is licensed under the BSD 2-Clause "Simplified" License.
+
+BSD 2-Clause License
+
+Copyright (c) 2025, et-si.ai
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
This PR adds a dedicated "License" section to the README, explicitly stating the BSD 2-Clause "Simplified" License terms. This improves project transparency for contributors and users, ensuring clarity on permissions and limitations.

## Additional Notes:
- Please consider promoting this repository for GSSOC 2025! It’s beginner-friendly and welcomes contributions.
- If possible, add the "gssoc25" label to help GSSOC participants find and contribute to this project.
- Contributors: Check [CONTRIBUTING.md](https://github.com/etsi-ai/etsi-failprint/blob/main/CONTRIBUTING.md) for guidelines.